### PR TITLE
Remove Sidebar imports from patient pages

### DIFF
--- a/src/pages/PatientAddIndicator.tsx
+++ b/src/pages/PatientAddIndicator.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-import Sidebar from "@/components/Sidebar";
 import MobileLayout from "@/components/MobileLayout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/PatientAddIndicator.tsx
+++ b/src/pages/PatientAddIndicator.tsx
@@ -175,17 +175,14 @@ const PatientAddIndicator = () => {
 
   if (isLoading) {
     return (
-      <div className="flex h-screen bg-gray-50">
-        <div className="hidden lg:block">
-          <Sidebar />
-        </div>
-        <div className="flex-1 flex items-center justify-center">
+      <MobileLayout>
+        <div className="flex items-center justify-center min-h-64">
           <div className="text-center">
             <div className="animate-spin h-8 w-8 border-4 border-blue-600 border-t-transparent rounded-full mx-auto mb-2"></div>
             <p className="text-gray-600">Carregando...</p>
           </div>
         </div>
-      </div>
+      </MobileLayout>
     );
   }
 

--- a/src/pages/PatientGraphSelector.tsx
+++ b/src/pages/PatientGraphSelector.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, TrendingUp, BarChart3, Plus } from "lucide-react";
-import Sidebar from "@/components/Sidebar";
 import MobileLayout from "@/components/MobileLayout";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/src/pages/PatientGraphView.tsx
+++ b/src/pages/PatientGraphView.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
   X,
 } from "lucide-react";
-import Sidebar from "@/components/Sidebar";
 import MobileLayout from "@/components/MobileLayout";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/src/pages/PatientIndicators.tsx
+++ b/src/pages/PatientIndicators.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { Plus, Activity, TrendingUp, Filter } from "lucide-react";
-import Sidebar from "@/components/Sidebar";
 import MobileLayout from "@/components/MobileLayout";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/src/pages/PatientProfile.tsx
+++ b/src/pages/PatientProfile.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Camera, User, Plus, Search, Share2, X } from "lucide-react";
-import Sidebar from "@/components/Sidebar";
 import MobileLayout from "@/components/MobileLayout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/pages/PatientProfile.tsx
+++ b/src/pages/PatientProfile.tsx
@@ -439,14 +439,11 @@ const PatientProfile = () => {
 
   if (!user) {
     return (
-      <div className="flex h-screen bg-gray-50">
-        <div className="hidden lg:block">
-          <Sidebar />
-        </div>
-        <div className="flex-1 flex items-center justify-center">
+      <MobileLayout>
+        <div className="flex items-center justify-center min-h-64">
           <p className="text-gray-600">Carregando usuário...</p>
         </div>
-      </div>
+      </MobileLayout>
     );
   }
 
@@ -1125,7 +1122,7 @@ const PatientProfile = () => {
             )}
 
             <p className="text-sm text-gray-500">
-              O médico poderá visualizar suas informações pessoais, dados
+              O m��dico poderá visualizar suas informações pessoais, dados
               médicos e histórico de indicadores. Você pode revogar este acesso
               a qualquer momento.
             </p>


### PR DESCRIPTION
Remove unused Sidebar component imports from multiple patient pages:

- PatientAddIndicator.tsx
- PatientGraphSelector.tsx  
- PatientGraphView.tsx
- PatientIndicators.tsx
- PatientProfile.tsx

Update loading state layouts in PatientAddIndicator and PatientProfile to use MobileLayout instead of custom flex containers with Sidebar references.

All pages now consistently use MobileLayout component without the unused Sidebar import.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/270ee451fed04fc1927c640166b95f2f/flare-den)

👀 [Preview Link](https://270ee451fed04fc1927c640166b95f2f-flare-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>270ee451fed04fc1927c640166b95f2f</projectId>-->
<!--<branchName>flare-den</branchName>-->