### PR TITLE
Add markdown formatter for ChatGPT text display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import ResetPassword from "./pages/ResetPassword";
 import MigrateUser from "./pages/MigrateUser";
 import TermsOfService from "./pages/TermsOfService";
 import TermsTest from "./pages/TermsTest";
+import { MarkdownTest } from "./components/MarkdownTest";
 
 const queryClient = new QueryClient();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,7 @@ const App = () => (
               <Route path="/migrate-user" element={<MigrateUser />} />
               <Route path="/select-profession" element={<SelectProfession />} />
               <Route path="/add-crm" element={<AddCRM />} />
+              <Route path="/markdown-test" element={<MarkdownTest />} />
               <Route
                 path="/dashboard"
                 element={

--- a/src/components/MarkdownTest.tsx
+++ b/src/components/MarkdownTest.tsx
@@ -1,37 +1,48 @@
 import React from 'react';
 import { FormattedChatGPTText } from '@/lib/markdown-formatter';
 
-const testText = `# Resultado do Diagnóstico
+const testText = `# Resultado do Diagnóstico Médico
 
-## Análise dos Dados
+## Análise dos Dados do Paciente
 
-Com base nos indicadores analisados, posso observar:
+Com base nos indicadores analisados durante o período de monitoramento, posso observar os seguintes padrões:
 
 ### Principais Observações:
 
-1. **Tendência de Aumento de Peso**: O paciente apresentou ganho de peso progressivo nos últimos meses
-2. **Pressão Arterial**: Valores consistentemente elevados
-3. **Glicemia**: Oscilações significativas foram detectadas
+1. **Tendência de Aumento de Peso**: O paciente apresentou ganho de peso progressivo nos últimos 3 meses, com *variação* de aproximadamente 5kg
+2. **Pressão Arterial**: Valores consistentemente elevados, especialmente no período matutino
+3. **Glicemia**: Oscilações significativas foram detectadas, com picos após as refeições
+4. **Frequência Cardíaca**: Padrão *irregular* durante exercícios físicos
 
-### Recomendações:
+### Recomendações Médicas:
 
-- Monitoramento *contínuo* da pressão arterial
-- Ajuste na medicação conforme protocolo
-- Acompanhamento nutricional especializado
+- Monitoramento **contínuo** da pressão arterial (3x ao dia)
+- Ajuste na medicação conforme protocolo estabelecido
+- Acompanhamento nutricional especializado com \`dieta hipossódica\`
+- Exercícios físicos moderados sob supervisão
+- Controle glicêmico rigoroso
 
-#### Código de Exemplo:
+#### Parâmetros de Referência:
 
 \`\`\`
-// Exemplo de monitoramento
-const pressao = {
-  sistolica: 140,
-  diastolica: 90
-};
+Pressão Arterial Normal:
+- Sistólica: < 120 mmHg
+- Diastólica: < 80 mmHg
+
+Glicemia de Jejum:
+- Normal: 70-99 mg/dL
+- Pré-diabetes: 100-125 mg/dL
 \`\`\`
 
-**Observação importante**: Este diagnóstico deve ser \`validado\` por um médico especialista.
+### Próximas Consultas:
 
-*Consulte sempre um profissional de saúde qualificado.*`;
+- **Cardiologia**: Em 15 dias
+- **Endocrinologia**: Em 30 dias
+- **Nutrição**: Semanal por 1 mês
+
+**Observação importante**: Este diagnóstico deve ser \`validado\` por um médico especialista. Não interrompa medicações sem orientação médica.
+
+*Consulte sempre um profissional de saúde qualificado para esclarecimentos adicionais.*`;
 
 export function MarkdownTest() {
   return (

--- a/src/components/MarkdownTest.tsx
+++ b/src/components/MarkdownTest.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FormattedChatGPTText } from '@/lib/markdown-formatter';
+import React from "react";
+import { FormattedChatGPTText } from "@/lib/markdown-formatter";
 
 const testText = `# Resultado do Diagnóstico Médico
 

--- a/src/components/MarkdownTest.tsx
+++ b/src/components/MarkdownTest.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { FormattedChatGPTText } from '@/lib/markdown-formatter';
+
+const testText = `# Resultado do Diagnóstico
+
+## Análise dos Dados
+
+Com base nos indicadores analisados, posso observar:
+
+### Principais Observações:
+
+1. **Tendência de Aumento de Peso**: O paciente apresentou ganho de peso progressivo nos últimos meses
+2. **Pressão Arterial**: Valores consistentemente elevados
+3. **Glicemia**: Oscilações significativas foram detectadas
+
+### Recomendações:
+
+- Monitoramento *contínuo* da pressão arterial
+- Ajuste na medicação conforme protocolo
+- Acompanhamento nutricional especializado
+
+#### Código de Exemplo:
+
+\`\`\`
+// Exemplo de monitoramento
+const pressao = {
+  sistolica: 140,
+  diastolica: 90
+};
+\`\`\`
+
+**Observação importante**: Este diagnóstico deve ser \`validado\` por um médico especialista.
+
+*Consulte sempre um profissional de saúde qualificado.*`;
+
+export function MarkdownTest() {
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white">
+      <h2 className="text-2xl font-bold mb-4">Teste de Formatação Markdown</h2>
+      <div className="border border-gray-300 rounded-lg p-4 bg-gray-50">
+        <FormattedChatGPTText text={testText} />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/markdown-formatter.tsx
+++ b/src/lib/markdown-formatter.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+
+export interface MarkdownFormatterProps {
+  text: string;
+  className?: string;
+}
+
+/**
+ * Formats text with basic markdown patterns commonly used by ChatGPT
+ * Supports: **bold**, ### headers, - bullet points, numbered lists
+ */
+export function formatChatGPTText(text: string): React.ReactNode[] {
+  if (!text) return [];
+
+  const lines = text.split('\n');
+  const elements: React.ReactNode[] = [];
+  let key = 0;
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    
+    // Empty line - add spacing
+    if (!trimmedLine) {
+      elements.push(<br key={key++} />);
+      continue;
+    }
+
+    // Headers (### text)
+    if (trimmedLine.startsWith('###')) {
+      const headerText = trimmedLine.replace(/^###\s*/, '');
+      elements.push(
+        <h3 key={key++} className="text-lg font-semibold text-gray-900 mt-4 mb-2">
+          {formatInlineText(headerText)}
+        </h3>
+      );
+      continue;
+    }
+
+    // Secondary headers (## text)
+    if (trimmedLine.startsWith('##')) {
+      const headerText = trimmedLine.replace(/^##\s*/, '');
+      elements.push(
+        <h2 key={key++} className="text-xl font-bold text-gray-900 mt-4 mb-2">
+          {formatInlineText(headerText)}
+        </h2>
+      );
+      continue;
+    }
+
+    // Bullet points (- text or * text)
+    if (trimmedLine.match(/^[-*]\s+/)) {
+      const bulletText = trimmedLine.replace(/^[-*]\s+/, '');
+      elements.push(
+        <div key={key++} className="flex items-start gap-2 ml-4 mb-1">
+          <span className="text-gray-600 mt-1">•</span>
+          <span>{formatInlineText(bulletText)}</span>
+        </div>
+      );
+      continue;
+    }
+
+    // Numbered lists (1. text, 2. text, etc.)
+    if (trimmedLine.match(/^\d+\.\s+/)) {
+      const match = trimmedLine.match(/^(\d+)\.\s+(.+)/);
+      if (match) {
+        const [, number, listText] = match;
+        elements.push(
+          <div key={key++} className="flex items-start gap-2 ml-4 mb-1">
+            <span className="text-gray-600 font-medium min-w-6">{number}.</span>
+            <span>{formatInlineText(listText)}</span>
+          </div>
+        );
+        continue;
+      }
+    }
+
+    // Regular paragraph
+    elements.push(
+      <p key={key++} className="mb-2 leading-relaxed">
+        {formatInlineText(trimmedLine)}
+      </p>
+    );
+  }
+
+  return elements;
+}
+
+/**
+ * Formats inline text with bold (**text**) and other inline formatting
+ */
+function formatInlineText(text: string): React.ReactNode[] {
+  if (!text) return [];
+
+  const parts: React.ReactNode[] = [];
+  let key = 0;
+  let currentIndex = 0;
+
+  // Handle **bold** text
+  const boldRegex = /\*\*(.*?)\*\*/g;
+  let match;
+
+  while ((match = boldRegex.exec(text)) !== null) {
+    // Add text before the bold part
+    if (match.index > currentIndex) {
+      const beforeText = text.slice(currentIndex, match.index);
+      parts.push(beforeText);
+    }
+
+    // Add the bold text
+    parts.push(
+      <strong key={key++} className="font-semibold text-gray-900">
+        {match[1]}
+      </strong>
+    );
+
+    currentIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text
+  if (currentIndex < text.length) {
+    parts.push(text.slice(currentIndex));
+  }
+
+  return parts.length > 0 ? parts : [text];
+}
+
+/**
+ * React component that renders formatted ChatGPT text
+ */
+export function FormattedChatGPTText({ text, className = "" }: MarkdownFormatterProps) {
+  const formattedElements = formatChatGPTText(text);
+
+  return (
+    <div className={`text-sm text-gray-800 leading-relaxed ${className}`}>
+      {formattedElements}
+    </div>
+  );
+}

--- a/src/lib/markdown-formatter.tsx
+++ b/src/lib/markdown-formatter.tsx
@@ -28,8 +28,8 @@ export function formatChatGPTText(text: string): React.ReactNode[] {
       if (inCodeBlock) {
         // End of code block
         elements.push(
-          <pre key={key++} className="bg-gray-800 text-green-400 rounded-lg p-3 mt-2 mb-2 text-sm font-mono overflow-x-auto">
-            <code>{codeBlockContent.join('\n')}</code>
+          <pre key={key++} className="bg-gray-900 text-gray-100 rounded-lg p-4 mt-3 mb-3 text-sm font-mono overflow-x-auto border border-gray-700">
+            <code className="block">{codeBlockContent.join('\n')}</code>
           </pre>
         );
         codeBlockContent = [];

--- a/src/lib/markdown-formatter.tsx
+++ b/src/lib/markdown-formatter.tsx
@@ -124,8 +124,8 @@ export function formatChatGPTText(text: string): React.ReactNode[] {
   // If there's an unclosed code block, add it
   if (inCodeBlock && codeBlockContent.length > 0) {
     elements.push(
-      <pre key={key++} className="bg-gray-800 text-green-400 rounded-lg p-3 mt-2 mb-2 text-sm font-mono overflow-x-auto">
-        <code>{codeBlockContent.join('\n')}</code>
+      <pre key={key++} className="bg-gray-900 text-gray-100 rounded-lg p-4 mt-3 mb-3 text-sm font-mono overflow-x-auto border border-gray-700">
+        <code className="block">{codeBlockContent.join('\n')}</code>
       </pre>
     );
   }

--- a/src/lib/markdown-formatter.tsx
+++ b/src/lib/markdown-formatter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 export interface MarkdownFormatterProps {
   text: string;
@@ -12,7 +12,7 @@ export interface MarkdownFormatterProps {
 export function formatChatGPTText(text: string): React.ReactNode[] {
   if (!text) return [];
 
-  const lines = text.split('\n');
+  const lines = text.split("\n");
   const elements: React.ReactNode[] = [];
   let key = 0;
 
@@ -24,13 +24,16 @@ export function formatChatGPTText(text: string): React.ReactNode[] {
     const trimmedLine = line.trim();
 
     // Handle code blocks (```)
-    if (trimmedLine.startsWith('```')) {
+    if (trimmedLine.startsWith("```")) {
       if (inCodeBlock) {
         // End of code block
         elements.push(
-          <pre key={key++} className="bg-gray-900 text-gray-100 rounded-lg p-4 mt-3 mb-3 text-sm font-mono overflow-x-auto border border-gray-700">
-            <code className="block">{codeBlockContent.join('\n')}</code>
-          </pre>
+          <pre
+            key={key++}
+            className="bg-gray-900 text-gray-100 rounded-lg p-4 mt-3 mb-3 text-sm font-mono overflow-x-auto border border-gray-700"
+          >
+            <code className="block">{codeBlockContent.join("\n")}</code>
+          </pre>,
         );
         codeBlockContent = [];
         inCodeBlock = false;
@@ -54,46 +57,49 @@ export function formatChatGPTText(text: string): React.ReactNode[] {
     }
 
     // Headers (### text)
-    if (trimmedLine.startsWith('###')) {
-      const headerText = trimmedLine.replace(/^###\s*/, '');
+    if (trimmedLine.startsWith("###")) {
+      const headerText = trimmedLine.replace(/^###\s*/, "");
       elements.push(
-        <h3 key={key++} className="text-lg font-semibold text-gray-900 mt-4 mb-2">
+        <h3
+          key={key++}
+          className="text-lg font-semibold text-gray-900 mt-4 mb-2"
+        >
           {formatInlineText(headerText)}
-        </h3>
+        </h3>,
       );
       continue;
     }
 
     // Secondary headers (## text)
-    if (trimmedLine.startsWith('##')) {
-      const headerText = trimmedLine.replace(/^##\s*/, '');
+    if (trimmedLine.startsWith("##")) {
+      const headerText = trimmedLine.replace(/^##\s*/, "");
       elements.push(
         <h2 key={key++} className="text-xl font-bold text-gray-900 mt-4 mb-2">
           {formatInlineText(headerText)}
-        </h2>
+        </h2>,
       );
       continue;
     }
 
     // Primary headers (# text)
-    if (trimmedLine.startsWith('#') && !trimmedLine.startsWith('##')) {
-      const headerText = trimmedLine.replace(/^#\s*/, '');
+    if (trimmedLine.startsWith("#") && !trimmedLine.startsWith("##")) {
+      const headerText = trimmedLine.replace(/^#\s*/, "");
       elements.push(
         <h1 key={key++} className="text-2xl font-bold text-gray-900 mt-6 mb-3">
           {formatInlineText(headerText)}
-        </h1>
+        </h1>,
       );
       continue;
     }
 
     // Bullet points (- text or * text)
     if (trimmedLine.match(/^[-*]\s+/)) {
-      const bulletText = trimmedLine.replace(/^[-*]\s+/, '');
+      const bulletText = trimmedLine.replace(/^[-*]\s+/, "");
       elements.push(
         <div key={key++} className="flex items-start gap-2 ml-4 mb-1">
           <span className="text-gray-600 mt-1 text-sm">•</span>
           <span className="flex-1">{formatInlineText(bulletText)}</span>
-        </div>
+        </div>,
       );
       continue;
     }
@@ -105,9 +111,11 @@ export function formatChatGPTText(text: string): React.ReactNode[] {
         const [, number, listText] = match;
         elements.push(
           <div key={key++} className="flex items-start gap-2 ml-4 mb-1">
-            <span className="text-gray-600 font-medium min-w-6 text-sm">{number}.</span>
+            <span className="text-gray-600 font-medium min-w-6 text-sm">
+              {number}.
+            </span>
             <span className="flex-1">{formatInlineText(listText)}</span>
-          </div>
+          </div>,
         );
         continue;
       }
@@ -117,16 +125,19 @@ export function formatChatGPTText(text: string): React.ReactNode[] {
     elements.push(
       <p key={key++} className="mb-2 leading-relaxed">
         {formatInlineText(trimmedLine)}
-      </p>
+      </p>,
     );
   }
 
   // If there's an unclosed code block, add it
   if (inCodeBlock && codeBlockContent.length > 0) {
     elements.push(
-      <pre key={key++} className="bg-gray-900 text-gray-100 rounded-lg p-4 mt-3 mb-3 text-sm font-mono overflow-x-auto border border-gray-700">
-        <code className="block">{codeBlockContent.join('\n')}</code>
-      </pre>
+      <pre
+        key={key++}
+        className="bg-gray-900 text-gray-100 rounded-lg p-4 mt-3 mb-3 text-sm font-mono overflow-x-auto border border-gray-700"
+      >
+        <code className="block">{codeBlockContent.join("\n")}</code>
+      </pre>,
     );
   }
 
@@ -167,7 +178,10 @@ function formatInlineText(text: string): React.ReactNode[] {
     {
       regex: /`([^`\n]+?)`/g,
       component: (content: string) => (
-        <code key={key++} className="bg-gray-200 text-gray-800 px-1 py-0.5 rounded text-xs font-mono">
+        <code
+          key={key++}
+          className="bg-gray-200 text-gray-800 px-1 py-0.5 rounded text-xs font-mono"
+        >
           {content}
         </code>
       ),
@@ -178,7 +192,11 @@ function formatInlineText(text: string): React.ReactNode[] {
   const segments = [{ text: currentText, isFormatted: false }];
 
   for (const pattern of patterns) {
-    const newSegments: Array<{ text: string; isFormatted: boolean; component?: React.ReactNode }> = [];
+    const newSegments: Array<{
+      text: string;
+      isFormatted: boolean;
+      component?: React.ReactNode;
+    }> = [];
 
     for (const segment of segments) {
       if (segment.isFormatted) {
@@ -222,17 +240,18 @@ function formatInlineText(text: string): React.ReactNode[] {
   }
 
   // Build final parts array
-  return segments.map(segment =>
-    segment.component || segment.text
-  ).filter(part =>
-    typeof part === 'string' ? part.length > 0 : true
-  );
+  return segments
+    .map((segment) => segment.component || segment.text)
+    .filter((part) => (typeof part === "string" ? part.length > 0 : true));
 }
 
 /**
  * React component that renders formatted ChatGPT text
  */
-export function FormattedChatGPTText({ text, className = "" }: MarkdownFormatterProps) {
+export function FormattedChatGPTText({
+  text,
+  className = "",
+}: MarkdownFormatterProps) {
   const formattedElements = formatChatGPTText(text);
 
   return (

--- a/src/pages/HospitalGraphView.tsx
+++ b/src/pages/HospitalGraphView.tsx
@@ -26,6 +26,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import { FormattedChatGPTText } from "@/lib/markdown-formatter";
 import {
   LineChart,
   Line,

--- a/src/pages/HospitalGraphView.tsx
+++ b/src/pages/HospitalGraphView.tsx
@@ -661,9 +661,7 @@ const HospitalGraphView = () => {
           </DialogHeader>
           <div className="space-y-4">
             <div className="bg-gray-50 rounded-lg p-4">
-              <div className="whitespace-pre-wrap text-sm text-gray-800 leading-relaxed">
-                {diagnosisResult}
-              </div>
+              <FormattedChatGPTText text={diagnosisResult} />
             </div>
             <div className="flex justify-end">
               <Button

--- a/src/pages/PatientGraphView.tsx
+++ b/src/pages/PatientGraphView.tsx
@@ -836,9 +836,7 @@ const PatientGraphView = () => {
           </DialogHeader>
           <div className="space-y-4">
             <div className="bg-gray-50 rounded-lg p-4">
-              <div className="whitespace-pre-wrap text-sm text-gray-800 leading-relaxed">
-                {diagnosisResult}
-              </div>
+              <FormattedChatGPTText text={diagnosisResult} />
             </div>
             <div className="flex justify-end">
               <Button

--- a/src/pages/PatientGraphView.tsx
+++ b/src/pages/PatientGraphView.tsx
@@ -27,6 +27,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import { FormattedChatGPTText } from "@/lib/markdown-formatter";
 import {
   LineChart,
   Line,


### PR DESCRIPTION
## Purpose

The user requested proper formatting for ChatGPT text responses that include markdown patterns like `**bold**` text. The current implementation was displaying raw markdown syntax instead of rendering it properly, making the text difficult to read and unprofessional in appearance.

## Code changes

- **Created new markdown formatter library** (`src/lib/markdown-formatter.tsx`):
  - Implements `FormattedChatGPTText` component for rendering markdown text
  - Supports headers (`#`, `##`, `###`), bold (`**text**`), italic (`*text*`), inline code (`` `text` ``), code blocks (``` ``` ```), bullet points, and numbered lists
  - Provides proper styling with Tailwind CSS classes

- **Updated patient and hospital graph views**:
  - Replaced raw text display with `FormattedChatGPTText` component in diagnosis result dialogs
  - Removed `whitespace-pre-wrap` styling in favor of proper markdown rendering

- **Added test component** (`src/components/MarkdownTest.tsx`):
  - Created comprehensive test page with sample medical text containing various markdown patterns
  - Added route `/markdown-test` for testing the formatter functionality

- **Updated routing** in `src/App.tsx` to include the new test route

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/33c4f6babe3d4c229e1282b685102193/flare-zone)

👀 [Preview Link](https://33c4f6babe3d4c229e1282b685102193-flare-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>33c4f6babe3d4c229e1282b685102193</projectId>-->
<!--<branchName>flare-zone</branchName>-->